### PR TITLE
Context dependent BracesAroundHashParameters.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -205,7 +205,7 @@ Style/BlockDelimiters:
     - 'spec/factories.rb'
 
 Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
+  EnforcedStyle: context_dependent
   SupportedStyles:
     # The `braces` style enforces braces around all method parameters that are
     # hashes.


### PR DESCRIPTION
what do you think of this instead? same as no_braces, but is `context_dependent`

https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/BracesAroundHashParameters

The `context_dependent` style checks that the last parameter
doesn't have braces around it, but requires braces if the
second to last parameter is also a hash literal.

bad:

    some_method(x, y, {a: 1, b: 2})
    some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)

good:

    some_method(x, y, a: 1, b: 2)
    some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2}) 