### PR TITLE
Lintception.

### DIFF
--- a/.circleci/test
+++ b/.circleci/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+Dir.glob('**/rubocop.yml').each do |path|
+  config = YAML.load_file(path)
+  next if config.keys == config.keys.sort
+  raise "#{path} config is not alphabetically sorted"
+end


### PR DESCRIPTION
```
style ⭠ lintception ❯ ./.circleci/test
Traceback (most recent call last):
        2: from ./.circleci/test:5:in `<main>'
        1: from ./.circleci/test:5:in `each'
./.circleci/test:8:in `block in <main>': ruby/rubocop.yml config is not alphabetically sorted (RuntimeError)
```