### PR TITLE
Set Layout/IndentArray to consistent.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -96,6 +96,28 @@ Layout/EndAlignment:
   AutoCorrect: false
   Severity: warning
 
+# Checks the indentation of the first element in an array literal.
+Layout/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: consistent
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 # Checks the indentation of the first key in a hash literal.
 Layout/IndentHash:
   # The value `special_inside_parentheses` means that hash literals with braces


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentArray

The `consistent` style enforces that the first element in an array
literal where the opening bracket and the first element are on
seprate lines is indented the same as an array literal which is not
defined inside a method call.

bad

    array = [
      :value
    ]
    but_in_a_method_call([
                          :its_like_this
    ])

good

    array = [
      :value
    ]
    and_in_a_method_call([
      :no_difference
    ])