### PR TITLE
Set Style/MultilineMemoization to braces

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -261,6 +261,12 @@ Style/ClassAndModuleChildren:
     - nested
     - compact
 
+Style/MultilineMemoization:
+  EnforcedStyle: braces
+  SupportedStyles:
+    - keyword
+    - braces
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   SupportedStyles:


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineMemoization
https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml#L1201

This cop checks expressions wrapping styles for multiline memoization.

bad

    foo ||= begin
      bar
      baz
    end

good

    foo ||= (
      bar
      baz
    )