### PR TITLE
Disable Style/EmptyCaseCondition cop.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -261,6 +261,10 @@ Style/ClassAndModuleChildren:
     - nested
     - compact
 
+# Allow empty condition in case statements
+Style/EmptyCaseCondition:
+  Enabled: false
+
 Style/MultilineMemoization:
   EnforcedStyle: braces
   SupportedStyles:


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyCaseCondition
https://github.com/rubocop-hq/rubocop/issues/3019#issuecomment-220761812

This allows empty case conditions to support the following:

    case
    when done?     then :paid
    when expired?  then :expired
    when expiring? then :expiring
    else :pending
    end

Instead of requiring:

    if done?
      :paid
    elsif expired?
      :expired
    elsif expiring?
      :expiring
    else
      :pending
    end