### PR TITLE
Set SpaceAroundEqualsInParameterDefault to no_spaces.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -150,6 +150,14 @@ Layout/MultilineMethodCallIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+# Checks that the equals signs in parameter default assignments have or don't
+# have surrounding space depending on configuration.
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
 #################### Style ###########################
 
 Style/BlockDelimiters:


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundEqualsInParameterDefault
http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutspacearoundequalsinparameterdefault

bad

    def some_method(arg1 = :default, arg2 = nil, arg3 = [])
      # do something...
    end

good

    def some_method(arg1=:default, arg2=nil, arg3=[])
      # do something...
    end

CC @thanx/style-team 