### PR TITLE
Disable RSpec/ContextWording cop.

### DIFF
--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -1,3 +1,8 @@
+RSpec/ContextWording:
+  Description: `context` block descriptions should start with 'when', or 'with'.
+  Enabled: false
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
+
 RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true


### PR DESCRIPTION
allows usage of different `context` prefixes instead of requiring `when`, `with`, `without`, `if`
https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording

@thanx/style-team 