### PR TITLE
Adjust Style/BlockDelimiters enforced style.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -161,7 +161,7 @@ Layout/SpaceAroundEqualsInParameterDefault:
 #################### Style ###########################
 
 Style/BlockDelimiters:
-  EnforcedStyle: semantic
+  EnforcedStyle: line_count_based
   SupportedStyles:
     # The `line_count_based` style enforces braces around single line blocks and
     # do..end around multi-line blocks.


### PR DESCRIPTION
This switches it back to the default enforced style.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters

I ran into required style changes that looked odd to me:
<img width="418" alt="screen shot 2018-06-26 at 12 52 57 pm" src="https://user-images.githubusercontent.com/885841/41935807-e04c7bf0-793f-11e8-9cba-8a81a72a0d50.png">
<img width="607" alt="screen shot 2018-06-26 at 12 56 01 pm" src="https://user-images.githubusercontent.com/885841/41935919-5448c6c6-7940-11e8-8c37-570efc9855e5.png">

IMO, all multi-line blocks should use `do`/`end` and all single-line blocks should use `{}`s.

Thoughts @thanx/style-team? 