### PR TITLE
Whitelist _ in Naming/UncommunicativeMethodParamName.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -158,6 +158,25 @@ Layout/SpaceAroundEqualsInParameterDefault:
     - space
     - no_space
 
+#################### Naming ##########################
+
+Naming/UncommunicativeMethodParamName:
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  # Whitelisted names that will not register an offense
+  AllowedNames:
+    - io
+    - id
+    - to
+    - by
+    - 'on'
+    - in
+    - at
+    - _
+  # Blacklisted names that will register an offense
+  ForbiddenNames: []
+
 #################### Style ###########################
 
 Style/BlockDelimiters:


### PR DESCRIPTION
Enables using _ as an parameter name when extending third-party classes.

For example:

    class Shoryuken::Subscriber
      include Shoryuken::Worker

      def perform(_, body)
        @body = body
        send(event) if respond_to?(event)
      end
    end