### PR TITLE
Exclude specs from Lint/AmbiguousBlockAssociation.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -376,6 +376,12 @@ Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*'
 
+#################### Lint ##################################
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 #################### Bundler ###############################
 
 Bundler/OrderedGems:


### PR DESCRIPTION
This exclusion is recommended (and used) by rubocop-hq.

https://github.com/rubocop-hq/rubocop/issues/4222#issuecomment-290655562
https://github.com/rubocop-hq/rubocop/blob/master/.rubocop.yml#L63