### PR TITLE
Exclude migrations from Style/GuardClause.

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -293,6 +293,13 @@ Style/ClassAndModuleChildren:
 Style/EmptyCaseCondition:
   Enabled: false
 
+# `MinBodyLength` defines the number of lines of the a body of an `if` or
+# `unless` needs to have to trigger this cop
+Style/GuardClause:
+  MinBodyLength: 1
+  Exclude:
+    - 'db/migrate/*'
+
 Style/MultilineMemoization:
   EnforcedStyle: braces
   SupportedStyles:


### PR DESCRIPTION
The allows using the following in migrations:

    unless table_exits?(:users)
      ...
    end

    unless column_exists?(:users, :email)
      ...
    end

Going to merge this in since it's not very controversial, but FYI @thanx/style-team