### PR TITLE
Set RSpec/ImplicitExpect enforced style to 'should'.

### DIFF
--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -25,6 +25,15 @@ RSpec/ExpectChange:
   - block
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
+RSpec/ImplicitExpect:
+  Description: Check that a consistent implicit expectation style is used.
+  Enabled: true
+  EnforcedStyle: should
+  SupportedStyles:
+  - is_expected
+  - should
+  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
+
 RSpec/MessageSpies:
   Description: Checks that message expectations are set using spies.
   Enabled: true


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/1.10.0/RuboCop/Cop/RSpec/ImplicitExpect

    # bad
    it { is_expected.to be_truthy }

    # good
    it { should be_truthy }