### PR TITLE
Set Style/RescueStandardError to implicit.

### DIFF
--- a/ruby/rubocop-ruby.yml
+++ b/ruby/rubocop-ruby.yml
@@ -329,6 +329,14 @@ Style/RegexpLiteral:
   # are found in the regexp string.
   AllowInnerSlashes: true
 
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+  # implicit: Do not include the error class, `rescue`
+  # explicit: Require an error class `rescue StandardError`
+  SupportedStyles:
+    - implicit
+    - explicit
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   SupportedStyles:


### PR DESCRIPTION
The default rescue is StandardError (not Exception) which may be confusing to some that are new to the language. However, given that this is a language default, adding `StandardError` makes `rescue`s less concise. This switches it so we don't have to explicitly specify the default `StandardError` for every rescue.