### PR TITLE
Set Style/YodaCondition to equality_operators_only.

### DIFF
--- a/ruby/rubocop-ruby.yml
+++ b/ruby/rubocop-ruby.yml
@@ -368,6 +368,14 @@ Style/WordArray:
   # The regular expression `WordRegex` decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
+Style/YodaCondition:
+  EnforcedStyle: equality_operators_only
+  SupportedStyles:
+    # check all comparison operators
+    - all_comparison_operators
+    # check only equality operators: `!=` and `==`
+    - equality_operators_only
+
 #################### Metrics ###############################
 
 Metrics/AbcSize:


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/YodaCondition

was triggering linting failures for
`1 < x && x < 10`
and wanted to require
`x > 1 && x < 10`

this changes allows the first to exist

thoughts?

i can see both ways, but `1 < x && x < 10` is easier for me to grok