### PR TITLE
Always use -> syntax over lambda syntax.

### DIFF
--- a/ruby/rubocop-ruby.yml
+++ b/ruby/rubocop-ruby.yml
@@ -318,6 +318,18 @@ Style/GuardClause:
   Exclude:
     - 'db/migrate/*'
 
+Style/Lambda:
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  StyleGuide: '#lambda-multi-line'
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.40'
+  EnforcedStyle: literal
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
 Style/MultilineMemoization:
   EnforcedStyle: braces
   SupportedStyles:


### PR DESCRIPTION
```
# bad
f = lambda { |x| x }
f = lambda { |x|
  x
}

# good
f = ->(x) { x }
f = ->(x) {
  x
}
```

Arrow syntax for lambdas was introduced in Ruby v1.9. This change favors the more concise syntax in all cases instead of having to use `->` for single-line blocks and `lambda` for multi-line blocks.
Thoughts?